### PR TITLE
fix(highest_backup_id): prevent sed delimiter collision

### DIFF
--- a/bin/git-branch-backup
+++ b/bin/git-branch-backup
@@ -6,7 +6,7 @@ function highest_backup_id {
 
     local prefix="${branch}.backup"
     git branch --list --color=never "${prefix}*" \
-        | sed "s/^..${prefix}//" \
+        | sed "s:^..${prefix}::" \
         | sort -nr \
         | head -n1
 }


### PR DESCRIPTION
by replacing the slash "/" as delimiter, which is common in git branch names (gitflow convention)
by a colon ":" which is an illegal character for git branch name, so that we ensure no more
collision is possible.

Fix #2 