### PR TITLE
Use 0 as default value

### DIFF
--- a/bin/git-branch-backup
+++ b/bin/git-branch-backup
@@ -28,7 +28,7 @@ function highest_backup_id {
 
 function new_backup_id {
     local branch="${1}"
-    local highest=$(highest_backup_id "${branch}") || return
+    local highest=$(highest_backup_id "${branch}") || 0
     echo $(( $highest + 1 ))
 }
 


### PR DESCRIPTION
After #4 , I suffered a new bug that caused `$highest + 1` to fail on branches without existing backups, because `$highest` was empty. This allows it to default to 0, making the first branch name use 1.